### PR TITLE
feat: Implement dynamic screen resolution

### DIFF
--- a/stupid_space_game/celestials.py
+++ b/stupid_space_game/celestials.py
@@ -2,7 +2,7 @@ from typing import Optional, List
 import pygame
 import math
 import stupid_space_game.graphics as graphics
-from stupid_space_game.constants import ORBITING_SPEED_FACTOR, SCREEN_WIDTH, SCREEN_HEIGHT
+import stupid_space_game.constants as game_constants
 
 BROAD_CHECK_COOLOFF = 100
 class CelestialEntity:
@@ -37,7 +37,7 @@ class CelestialEntity:
     def update(self) -> None:
         if self.orbit_parent is not None:
             # Update the orbit angle based on orbit speed
-            self.orbit_angle += ORBITING_SPEED_FACTOR*self.angular_velocity
+            self.orbit_angle += game_constants.ORBITING_SPEED_FACTOR*self.angular_velocity
             
             # Calculate the new position based on circular orbit
             # Using parametric equations for a circle: x = center_x + radius * cos(angle), y = center_y + radius * sin(angle)
@@ -50,7 +50,7 @@ class CelestialEntity:
             moon.update()
 
     def orbit_speed(self) -> float:
-        return self.angular_velocity * ORBITING_SPEED_FACTOR * self.orbit_radius
+        return self.angular_velocity * game_constants.ORBITING_SPEED_FACTOR * self.orbit_radius
 
     def orbit_velocity(self) -> pygame.math.Vector2:
         return pygame.math.Vector2(
@@ -103,9 +103,9 @@ class CelestialEntity:
 def is_on_screen_broad_check(celestial: CelestialEntity, buffer_size: int) -> bool:
     # Calculate the boundaries of the expanded screen area
     extended_min_x = 0 - buffer_size
-    extended_max_x = SCREEN_WIDTH + buffer_size
+    extended_max_x = game_constants.SCREEN_WIDTH + buffer_size
     extended_min_y = 0 - buffer_size
-    extended_max_y = SCREEN_HEIGHT + buffer_size    
+    extended_max_y = game_constants.SCREEN_HEIGHT + buffer_size    
 
     # Calculate the planet's bounding box edges
     planet_min_x = celestial.position.x - celestial.radius

--- a/stupid_space_game/graphics.py
+++ b/stupid_space_game/graphics.py
@@ -1,13 +1,14 @@
-from stupid_space_game.constants import SCREEN_WIDTH, SCREEN_HEIGHT
+import stupid_space_game.constants as game_constants
 import pygame
 import os
 from typing import List, Tuple, Optional
 import math
-def init_graphics() -> pygame.Surface:
+def init_graphics() -> Tuple[pygame.Surface, int, int]:
     pygame.init()
-    screen = pygame.display.set_mode((SCREEN_WIDTH, SCREEN_HEIGHT), pygame.FULLSCREEN | pygame.NOFRAME)
+    screen = pygame.display.set_mode((0, 0), pygame.FULLSCREEN | pygame.NOFRAME)
     pygame.display.set_caption("Stupid Space Game")
-    return screen
+    width, height = screen.get_size()
+    return screen, width, height
 
 class CelestialBodyGraphics:
     def __init__(self, sprite_id: str, radius: int = 50) -> None:
@@ -75,7 +76,7 @@ class BackgroundGraphics:
     def __init__(self) -> None:
         background = pygame.image.load('./assets/background.png').convert()
         self.oscillation_amplitude = 500
-        self.background = pygame.transform.scale(background, (1000 + SCREEN_WIDTH,1000 + SCREEN_HEIGHT))
+        self.background = pygame.transform.scale(background, (1000 + game_constants.SCREEN_WIDTH,1000 + game_constants.SCREEN_HEIGHT))
         self.oscillation_angle = 0.01
 
     

--- a/stupid_space_game/main.py
+++ b/stupid_space_game/main.py
@@ -1,6 +1,7 @@
 import sys
 import pygame
 from stupid_space_game.constants import SCREEN_WIDTH, SCREEN_HEIGHT, FPS
+import stupid_space_game.constants as game_constants
 import stupid_space_game.graphics as graphics
 from stupid_space_game.world import World
 from stupid_space_game.controls import player1_input_control,  player2_input_control, player_shoot_check
@@ -9,7 +10,9 @@ import stupid_space_game.missile_logic as missile_logic
 
 
 def main():
-    screen = graphics.init_graphics()
+    screen, actual_width, actual_height = graphics.init_graphics()
+    game_constants.SCREEN_WIDTH = actual_width
+    game_constants.SCREEN_HEIGHT = actual_height
     ui.ui_init()
     ui.show_full_screen(screen, './assets/splash/title.png')
 

--- a/stupid_space_game/missile_logic.py
+++ b/stupid_space_game/missile_logic.py
@@ -1,7 +1,7 @@
 import pygame
 from pygame.math import Vector2
 from stupid_space_game.ui import get_game_font, get_numbers_ui, get_large_font
-from stupid_space_game.constants import SCREEN_WIDTH, SCREEN_HEIGHT, MISSILE_GRAIN
+import stupid_space_game.constants as game_constants
 
 TRIANGLE_COLOR = pygame.Color('yellow')
 HYPOTENUSE_COLOR = pygame.Color('magenta') # Original hypotenuse path
@@ -17,8 +17,8 @@ MISSILE_SPEED_PPT = 5000 # Pixels Per Thousand ms
 
 EXPLOSION_COLOR_INNER = pygame.Color('yellow')
 EXPLOSION_COLOR_OUTER = pygame.Color('darkorange')
-EXPLOSION_RADIUS_INNER_MAX = MISSILE_GRAIN // 2
-EXPLOSION_RADIUS_OUTER_MAX = MISSILE_GRAIN
+EXPLOSION_RADIUS_INNER_MAX = game_constants.MISSILE_GRAIN // 2
+EXPLOSION_RADIUS_OUTER_MAX = game_constants.MISSILE_GRAIN
 EXPLOSION_DURATION_MS = 300
 
 # Define Text Colors Globally
@@ -31,7 +31,7 @@ def clamp_rect_to_screen(rect: pygame.Rect) -> pygame.Rect:
     """Clamps a rectangle to the screen boundaries defined by global constants."""
     clamped_rect = rect.copy()
     # Use global constants directly
-    clamped_rect.clamp_ip(pygame.Rect(0, 0, SCREEN_WIDTH, SCREEN_HEIGHT))
+    clamped_rect.clamp_ip(pygame.Rect(0, 0, game_constants.SCREEN_WIDTH, game_constants.SCREEN_HEIGHT))
     return clamped_rect
 
 def animate_missile_and_explosion(
@@ -43,7 +43,7 @@ def animate_missile_and_explosion(
     players_guess: int
 ):
     """Animates missile flight and explosion using Vector2."""
-    guessed_length_px = players_guess * MISSILE_GRAIN
+    guessed_length_px = players_guess * game_constants.MISSILE_GRAIN
     # start_vec and target_vec are already vectors
     direction_vec = target_vec - start_vec
     true_length = direction_vec.length()
@@ -126,7 +126,7 @@ def draw_final_state(
 
     # --- Calculations ---
     result_damage = 0
-    guessed_length_px = players_guess * MISSILE_GRAIN
+    guessed_length_px = players_guess * game_constants.MISSILE_GRAIN
     # start_vec, target_vec already vectors
     direction_vec = target_vec - start_vec
     true_length = direction_vec.length()
@@ -154,7 +154,7 @@ def draw_final_state(
     if delta_x > 0 or delta_y > 0: pygame.draw.line(screen, HYPOTENUSE_COLOR, start_pos_tuple, target_pos_tuple, HYPOTENUSE_LINE_WIDTH)
     # Draw Side Labels (using RESULT_TEXT_COLOR)
     if delta_x >= MIN_LABEL_LENGTH:
-        text_horiz_str = f"{int(delta_x) // MISSILE_GRAIN}"
+        text_horiz_str = f"{int(delta_x) // game_constants.MISSILE_GRAIN}"
         # Use get_game_font()
         text_horiz_surf = get_game_font().render(text_horiz_str, True, RESULT_TEXT_COLOR)
         text_horiz_rect = text_horiz_surf.get_rect(centerx=int((start_vec.x + target_vec.x) / 2))
@@ -164,7 +164,7 @@ def draw_final_state(
         final_horiz_rect = clamp_rect_to_screen(text_horiz_rect)
         screen.blit(text_horiz_surf, final_horiz_rect)
     if delta_y >= MIN_LABEL_LENGTH:
-        text_vert_str = f"{int(delta_y) // MISSILE_GRAIN}"
+        text_vert_str = f"{int(delta_y) // game_constants.MISSILE_GRAIN}"
         # Use get_game_font()
         text_vert_surf = get_game_font().render(text_vert_str, True, RESULT_TEXT_COLOR)
         text_vert_rect = text_vert_surf.get_rect(centery=int((start_vec.y + target_vec.y) / 2))
@@ -187,17 +187,17 @@ def draw_final_state(
     pygame.draw.circle(screen, EXPLOSION_COLOR_INNER, explosion_center_tuple, EXPLOSION_RADIUS_INNER_MAX, 0)
 
     result = "Missed!"
-    if abs(true_length - players_guess*MISSILE_GRAIN) <= EXPLOSION_RADIUS_INNER_MAX:
+    if abs(true_length - players_guess*game_constants.MISSILE_GRAIN) <= EXPLOSION_RADIUS_INNER_MAX:
         result = f"Bullseye!"
-        precision = 1 + 10*abs(players_guess - true_length / MISSILE_GRAIN)
+        precision = 1 + 10*abs(players_guess - true_length / game_constants.MISSILE_GRAIN)
         result_damage = 100 / precision
-    elif abs(true_length - players_guess*MISSILE_GRAIN) <= EXPLOSION_RADIUS_OUTER_MAX:
+    elif abs(true_length - players_guess*game_constants.MISSILE_GRAIN) <= EXPLOSION_RADIUS_OUTER_MAX:
         result = "Scratched!"
         result_damage = 20
 
-    guess_vs_true_text = f"{result} | Missile: {players_guess} | true distance: {true_length / MISSILE_GRAIN: .1f}"
+    guess_vs_true_text = f"{result} | Missile: {players_guess} | true distance: {true_length / game_constants.MISSILE_GRAIN: .1f}"
     prompt_surf = get_large_font().render(guess_vs_true_text, True, PROMPT_TEXT_COLOR)
-    prompt_rect = prompt_surf.get_rect(center=(SCREEN_WIDTH // 2, 3*FONT_SIZE))
+    prompt_rect = prompt_surf.get_rect(center=(game_constants.SCREEN_WIDTH // 2, 3*FONT_SIZE))
     screen.blit(prompt_surf, prompt_rect)
     return result_damage
 
@@ -228,7 +228,7 @@ def draw_right_triangle_with_labels(
 
     # --- 3. Render, Position, Clamp, and Blit Labels (using get_game_font(), TEXT_COLOR) ---
     if delta_x >= MIN_LABEL_LENGTH:
-        text_horiz_str = f"{int(delta_x / MISSILE_GRAIN)}" # Use .0f for cleaner int display
+        text_horiz_str = f"{int(delta_x / game_constants.MISSILE_GRAIN)}" # Use .0f for cleaner int display
         # Use get_game_font()
         text_horiz_surf = get_game_font().render(text_horiz_str, True, TEXT_COLOR)
         text_horiz_rect = text_horiz_surf.get_rect(centerx=int((start_vec.x + target_vec.x) / 2))
@@ -240,7 +240,7 @@ def draw_right_triangle_with_labels(
         screen.blit(text_horiz_surf, final_horiz_rect)
 
     if delta_y >= MIN_LABEL_LENGTH:
-        text_vert_str = f"{int(delta_y / MISSILE_GRAIN)}"
+        text_vert_str = f"{int(delta_y / game_constants.MISSILE_GRAIN)}"
         # Use get_game_font()
         text_vert_surf = get_game_font().render(text_vert_str, True, TEXT_COLOR)
         text_vert_rect = text_vert_surf.get_rect(centery=int((start_vec.y + target_vec.y) / 2))
@@ -261,8 +261,8 @@ def missile_minigame(
     target_vec: Vector2,
 ):  
     diff_vector =  start_vec - target_vec
-    diff_vector.x = round_down(diff_vector.x, MISSILE_GRAIN)
-    diff_vector.y = round_down(diff_vector.y, MISSILE_GRAIN)
+    diff_vector.x = round_down(diff_vector.x, game_constants.MISSILE_GRAIN)
+    diff_vector.y = round_down(diff_vector.y, game_constants.MISSILE_GRAIN)
     start_vec = target_vec + diff_vector
 
     original_frame = screen.convert() 
@@ -318,10 +318,10 @@ def missile_minigame(
 
             # Use get_game_font()
             prompt_surf = get_game_font().render("Choose how far to launch the missile", True, PROMPT_TEXT_COLOR)
-            prompt_rect = prompt_surf.get_rect(center=(SCREEN_WIDTH // 2, 7*FONT_SIZE)) # Use global SCREEN_WIDTH
+            prompt_rect = prompt_surf.get_rect(center=(game_constants.SCREEN_WIDTH // 2, 7*FONT_SIZE)) # Use global SCREEN_WIDTH
             numbers_ui = get_numbers_ui()
             numbers_rect = numbers_ui.get_rect()
-            numbers_rect.centerx = SCREEN_WIDTH // 2
+            numbers_rect.centerx = game_constants.SCREEN_WIDTH // 2
             numbers_rect.top = 50
             screen.blit(numbers_ui, numbers_rect)
             screen.blit(prompt_surf, prompt_rect)

--- a/stupid_space_game/rockets.py
+++ b/stupid_space_game/rockets.py
@@ -2,12 +2,11 @@ from typing import Tuple
 import pygame
 import math
 import stupid_space_game.graphics as graphics
-from stupid_space_game.constants import SCREEN_WIDTH, SCREEN_HEIGHT, COLLISION_BUFFER
-from stupid_space_game.constants import DEFAULT_HP
+import stupid_space_game.constants as game_constants
 
 class Rocket:
     def __init__(self, x: float = 0, y: float = 0, rotation: float = 0) -> None:
-        self.hp = DEFAULT_HP
+        self.hp = game_constants.DEFAULT_HP
         self.mana = 0.0
         self.position = pygame.math.Vector2(x, y)
         self.velocity = pygame.math.Vector2(0, 0)
@@ -34,21 +33,21 @@ class Rocket:
         self.position += self.velocity
         # Wrap around screen edges (Atari-style)
         if self.position.x < 0:
-            self.position.x = SCREEN_WIDTH
-        elif self.position.x > SCREEN_WIDTH:
+            self.position.x = game_constants.SCREEN_WIDTH
+        elif self.position.x > game_constants.SCREEN_WIDTH:
             self.position.x = 0
         if self.position.y < 0:
-            self.position.y = SCREEN_HEIGHT
-        elif self.position.y > SCREEN_HEIGHT:
+            self.position.y = game_constants.SCREEN_HEIGHT
+        elif self.position.y > game_constants.SCREEN_HEIGHT:
             self.position.y = 0
         self.calc_collision_rect()
 
     def calc_collision_rect(self):
         self.broad_borders = (
-            self.position.x - COLLISION_BUFFER,
-            self.position.y - COLLISION_BUFFER,
-            self.position.x + COLLISION_BUFFER,
-            self.position.y + COLLISION_BUFFER
+            self.position.x - game_constants.COLLISION_BUFFER,
+            self.position.y - game_constants.COLLISION_BUFFER,
+            self.position.x + game_constants.COLLISION_BUFFER,
+            self.position.y + game_constants.COLLISION_BUFFER
         )
 
     def draw(self, screen: pygame.Surface) -> None:

--- a/stupid_space_game/ui.py
+++ b/stupid_space_game/ui.py
@@ -1,5 +1,5 @@
 import pygame
-from stupid_space_game.constants import SCREEN_WIDTH, SCREEN_HEIGHT
+import stupid_space_game.constants as game_constants
 
 GAME_FONT: pygame.font.Font = None
 LARGE_FONT: pygame.font.Font = None
@@ -150,7 +150,7 @@ def draw_fighter_ui(screen,
 
 def show_full_screen(screen, filepath):
     image = pygame.image.load(filepath)
-    image = pygame.transform.scale(image, (SCREEN_WIDTH, SCREEN_HEIGHT))
+    image = pygame.transform.scale(image, (screen.get_width(), screen.get_height()))
     screen.blit(image, (0, 0))
     pygame.display.update()
     while True:

--- a/stupid_space_game/world.py
+++ b/stupid_space_game/world.py
@@ -1,12 +1,11 @@
 from typing import Optional, Tuple, List
 import pygame
 import stupid_space_game.graphics as graphics
-from stupid_space_game.constants import SOLAR_SYSTEM, ORBITING_SPEED_FACTOR, SCREEN_WIDTH, SCREEN_HEIGHT
+import stupid_space_game.constants as game_constants
 import math
 from stupid_space_game.celestials import CelestialEntity
 from stupid_space_game.rockets import Rocket
 import stupid_space_game.physics as physics
-from stupid_space_game.constants import DEFAULT_HP
 from stupid_space_game.ui import draw_fighter_ui
 
 class World:
@@ -14,18 +13,18 @@ class World:
         self._celestials: List[CelestialEntity] = []
         self._initialize_solar_system()
         self.rocket1 = Rocket(
-            x=SCREEN_WIDTH // 4,
-            y=2 * SCREEN_HEIGHT // 3,
+            x=game_constants.SCREEN_WIDTH // 4,
+            y=2 * game_constants.SCREEN_HEIGHT // 3,
             rotation=270,
         )
         self.rocket2 = Rocket(
-            x=3 * SCREEN_WIDTH // 4, 
-            y=1 * SCREEN_HEIGHT // 3,
+            x=3 * game_constants.SCREEN_WIDTH // 4, 
+            y=1 * game_constants.SCREEN_HEIGHT // 3,
             rotation=90,
         )
     
     def _initialize_solar_system(self):
-        star_data = SOLAR_SYSTEM['star']
+        star_data = game_constants.SOLAR_SYSTEM['star']
         star_radius = star_data['size'] // 2
         star_graphics = graphics.CelestialBodyGraphics(
             star_data['sprite_id'], 
@@ -40,7 +39,7 @@ class World:
         )
         self._celestials.append(self.star)
         
-        for planet_data in SOLAR_SYSTEM['planets']:
+        for planet_data in game_constants.SOLAR_SYSTEM['planets']:
             planet_radius = planet_data['size'] // 2
             planet_graphics = graphics.CelestialBodyGraphics(planet_data['sprite_id'], planet_radius)
             
@@ -100,10 +99,10 @@ class World:
         draw_fighter_ui(
             screen, 
             self.rocket1.hp, 
-            DEFAULT_HP, 
+            game_constants.DEFAULT_HP, 
             self.rocket1.mana,
             self.rocket2.hp, 
-            DEFAULT_HP,
+            game_constants.DEFAULT_HP,
             self.rocket2.mana)
 
 


### PR DESCRIPTION
Makes the game start in fullscreen and adapt to the monitor's native resolution.

Key changes include:
- Modified `graphics.init_graphics` to initialize Pygame with `(0,0)` in fullscreen mode and retrieve the actual screen dimensions.
- Updated `main.py` to fetch these dynamic dimensions and update `constants.SCREEN_WIDTH` and `constants.SCREEN_HEIGHT` at runtime.
- Refactored various game modules (`celestials.py`, `rockets.py`, `missile_logic.py`, `graphics.py`, `world.py`, `ui.py`) to consistently use the (now dynamic) `constants.SCREEN_WIDTH` and `constants.SCREEN_HEIGHT` via an explicit module import (`import stupid_space_game.constants as game_constants`).
- Adjusted UI elements, particularly in `ui.py` (`show_full_screen`), to scale or position themselves based on the dynamic screen dimensions.
- Rocket starting positions, screen wrapping, and background graphics now adapt to the resolution.
- The positions and scales of celestial bodies defined in `SOLAR_SYSTEM` remain absolute as per the original design, which may require further adjustments for optimal display on all aspect ratios/resolutions.